### PR TITLE
Add caching to analytics computations

### DIFF
--- a/pages/analytics_utils.py
+++ b/pages/analytics_utils.py
@@ -94,8 +94,13 @@ def show_executive_summary(df, produtos_novos, produtos_existentes, empresa="MIN
         if criticos == 0 and alerta == 0:
             st.success("✅ Situação de estoque sob controle!")
 
+@st.cache_data(ttl=604800)
 def calculate_purchase_suggestions(produtos_existentes):
-    """Calculate purchase suggestions for products"""
+    """Calculate purchase suggestions for products.
+
+    Results are cached for one week to avoid recomputation when the
+    analytics page is opened frequently.
+    """
     
     def calcular_quando_vai_acabar(estoque, consumo_mensal):
         if consumo_mensal <= 0:


### PR DESCRIPTION
## Summary
- cache the heavy purchase suggestion calculations for one week
- introduce `preprocess_analytics_dataframe` to normalize analytics data with caching
- use the new preprocessing step in analytics page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d499d9274832db433d1e6875b0d02