### PR TITLE
Add admin user

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -44,6 +44,14 @@ def create_default_users():
             "department": "Administração",
             "created": datetime.now().isoformat(),
             "last_login": None
+        },
+        "admin": {
+            "password": hash_password("3347"),
+            "role": "admin",
+            "name": "MINIPA Admin",
+            "department": "Administração",
+            "created": datetime.now().isoformat(),
+            "last_login": None
         }
     }
     save_users(default_users)


### PR DESCRIPTION
## Summary
- add a new default `admin` user to match existing permissions

## Testing
- `python -m py_compile app.py auth.py pages/*.py bd/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685d4c5c0f78832d818434c952b61696