### PR TITLE
Cache Snowflake connection in Streamlit session

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,12 +2,26 @@ import streamlit as st
 import auth
 import sys
 import os
+import atexit
 
 # Authentication check
 if not auth.require_auth():
     st.stop()
 
 st.set_page_config(page_title="Dashboard Corporativo", page_icon="🏢", layout="wide")
+
+
+def _close_snowflake_connection() -> None:
+    """Close cached Snowflake connection if it exists."""
+    conn = st.session_state.get("snowflake_conn")
+    if conn and not conn.is_closed():
+        conn.close()
+
+
+try:  # Streamlit <-> process cleanup
+    st.on_session_end(_close_snowflake_connection)
+except AttributeError:
+    atexit.register(_close_snowflake_connection)
 
 # Add pages directory to path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
## Summary
- cache and reuse Snowflake connection via `st.session_state`
- ensure cached connection is closed when the session ends

## Testing
- `pytest`
- `python -m py_compile bd/snowflake_connection.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_689117094208832d9789f845c9d4f491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resource management by ensuring Snowflake connections are automatically closed when a Streamlit session ends or the app process exits.

* **Refactor**
  * Enhanced connection caching and error message formatting for Snowflake connections, improving reliability and clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->